### PR TITLE
Fix: persist and log appointment endTime from request payload

### DIFF
--- a/src/main/java/com/khepraptah/khepra_site_backend/controller/AppointmentController.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/controller/AppointmentController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.swing.text.html.Option;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Vector;
 import java.net.URI;

--- a/src/main/java/com/khepraptah/khepra_site_backend/controller/DefaultController.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/controller/DefaultController.java
@@ -6,13 +6,8 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/")
 public class DefaultController {
 
-    public DefaultController() {
-        System.out.println("DefaultController called from controller");
-    }
-
     @GetMapping("/")
-    public String getAllAppointments() {
-        System.out.println("getAllAppointments called from controller");
+    public String controllerMethod() {
         return "Default Controller";
     }
 }

--- a/src/main/java/com/khepraptah/khepra_site_backend/controller/EventController.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/controller/EventController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.swing.text.html.Option;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Vector;
 import java.net.URI;
@@ -36,10 +37,6 @@ public class EventController {
     public ResponseEntity<EventDTO> createEvent(@RequestBody EventDTO eventDTO) {
         EventDTO created = eventService.saveEvent(eventDTO);
         URI location = URI.create("/api/events/" + created.id());
-
-        System.out.println("TESTING: Received event name: " + created.eventName());
-        System.out.println("TESTING: Received event type: " + created.eventType());
-
 
         return ResponseEntity.created(location).body(created);
     }

--- a/src/main/java/com/khepraptah/khepra_site_backend/exception/ConflictException.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/exception/ConflictException.java
@@ -1,0 +1,7 @@
+package com.khepraptah.khepra_site_backend.exception;
+
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/khepraptah/khepra_site_backend/model/Appointment.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/model/Appointment.java
@@ -7,10 +7,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.*;
 
 
+import java.time.LocalDateTime;
 import java.util.Date;
 @Entity
 @Table(name = "appointments")
-public class Appointment {
+public class Appointment implements Schedulable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -30,30 +31,129 @@ public class Appointment {
     @Column(name = "date")
     private Date date;
 
+    @Column(name = "start_time")
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time")
+    private LocalDateTime endTime;
+
+    @Column(name = "duration")
+    private int durationMinutes;
+
+    @Column(name = "city")
+    private String city;
+
     @Column(name = "isVirtual")
     private Boolean isVirtual;
 
-    public Long getId() { return id; }
-    public void setId(Long id) { this.id = id; }
+    @Column(name = "created_by_admin")
+    private Boolean createdByAdmin;
 
-    public String getType() { return type; }
-    public void setType(String type) { this.type = type; }
+    public Long getId() {
+        return id;
+    }
 
-    public String getUserId() { return userId; }
-    public void setUserId(String userId) { this.userId = userId; }
+    public void setId(Long id) {
+        this.id = id;
+    }
 
-    public String getName() { return name; }
-    public void setName(String name) { this.name = name; }
+    public String getType() {
+        return type;
+    }
 
-    public String getEmail() { return email; }
-    public void setEmail(String email) {this.email = email;}
+    public void setType(String type) {
+        this.type = type;
+    }
 
-    public String getPhoneNumber() { return phoneNumber; }
-    public void setPhoneNumber(String phoneNumber) { this.phoneNumber = phoneNumber; }
+    public String getUserId() {
+        return userId;
+    }
 
-    public Date getDate() { return date; }
-    public void setDate(Date date) { this.date = date; }
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
 
-    public Boolean getIsVirtual() { return isVirtual; }
-    public void setIsVirtual(Boolean isVirtual) { this.isVirtual = isVirtual; }
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    @Override
+    public LocalDateTime getStartTime() {
+        return this.startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public int getDuration() {
+        return durationMinutes;
+    }
+
+    public void setDuration(int durationMinutes) {
+        this.durationMinutes = durationMinutes;
+    }
+
+    public LocalDateTime getEndTime() {
+        return startTime.plusMinutes(durationMinutes);
+    }
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    @Override
+    public String getCity() { return this.city; }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public Boolean getIsVirtualRaw() {
+        return isVirtual;
+    }
+
+    public void setIsVirtual(Boolean isVirtual) {
+        this.isVirtual = isVirtual;
+    }
+
+    public Boolean getCreatedByAdmin() {
+        return createdByAdmin;
+    }
+
+    public void setCreatedByAdmin(Boolean createdByAdmin) {
+        this.createdByAdmin = createdByAdmin;
+    }
+
+    @Override
+    public boolean isVirtual() {
+        return Boolean.TRUE.equals(isVirtual); // safely handle null
+    }
 }

--- a/src/main/java/com/khepraptah/khepra_site_backend/model/AppointmentDTO.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/model/AppointmentDTO.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
-public record AppointmentDTO(Long id, String type, String userId, String name, String email, String phoneNumber, Date date, Boolean isVirtual) {
+public record AppointmentDTO(Long id, String type, String userId, String name, String email, String phoneNumber, Date date, LocalDateTime startTime, LocalDateTime endTime, int durationMinutes, String city, Boolean isVirtual, Boolean createdByAdmin) {
     public LocalDateTime getDate() {
         return date == null ? null : date.toInstant().atZone(java.time.ZoneId.systemDefault()).toLocalDateTime();
     }

--- a/src/main/java/com/khepraptah/khepra_site_backend/model/AppointmentType.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/model/AppointmentType.java
@@ -1,0 +1,18 @@
+package com.khepraptah.khepra_site_backend.model;
+
+public enum AppointmentType {
+    READING(30),
+    CLEANSING(45),
+    INITIATION(60),
+    WORKSHOP(90);
+
+    private final int durationMinutes;
+
+    AppointmentType(int durationMinutes) {
+        this.durationMinutes = durationMinutes;
+    }
+
+    public int getDurationMinutes() {
+        return durationMinutes;
+    }
+}

--- a/src/main/java/com/khepraptah/khepra_site_backend/model/Event.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/model/Event.java
@@ -7,11 +7,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.*;
 
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @Entity
 @Table(name = "events")
-public class Event {
+public class Event implements Schedulable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -30,6 +32,15 @@ public class Event {
 
     @Column(name = "end_date")
     private Date endDate;
+
+    @Column(name = "start_time")
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time")
+    private LocalDateTime endTime;
+
+    @Column(name = "duration")
+    private int durationMinutes;
 
     @Column(name = "street_address")
     private String streetAddress;
@@ -58,7 +69,6 @@ public class Event {
     public String getEventType() { return eventType; }
     public void setEventType(String eventType) { this.eventType = eventType; }
 
-
     public String getClientName() { return clientName; }
     public void setClientName(String clientName) { this.clientName = clientName; }
 
@@ -68,10 +78,37 @@ public class Event {
     public Date getEndDate() { return endDate; }
     public void setEndDate(Date endDate) { this.endDate = endDate; }
 
+    @Override
+    public LocalDateTime getStartTime() { return this.startTime; }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    @PrePersist
+    @PreUpdate
+    public void calculateEndTime() {
+        if (startTime != null && durationMinutes > 0) {
+            this.endTime = startTime.plusMinutes(durationMinutes);
+        }
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime.plusMinutes(durationMinutes);
+    }
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+
+    public int getDuration() { return durationMinutes; }
+    public void setDuration(int durationMinutes) { this.durationMinutes = durationMinutes; }
+
     public String getStreetAddress() { return streetAddress; }
     public void setStreetAddress(String streetAddress) {this.streetAddress = streetAddress;}
 
-    public String getCity() { return city; }
+    @Override
+    public String getCity() { return this.city; }
     public void setCity(String city) {this.city = city;}
 
     public String getState() { return state; }
@@ -83,6 +120,12 @@ public class Event {
     public String getDescription() { return description; }
     public void setDescription(String description) {this.description = description;}
 
-    public Boolean getIsVirtual() { return isVirtual; }
+    public Boolean getIsVirtualRaw() { return isVirtual; }
+
     public void setIsVirtual(Boolean isVirtual) { this.isVirtual = isVirtual; }
+
+    @Override
+    public boolean isVirtual() {
+        return Boolean.TRUE.equals(isVirtual);
+    }
 }

--- a/src/main/java/com/khepraptah/khepra_site_backend/model/EventDTO.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/model/EventDTO.java
@@ -1,5 +1,6 @@
 package com.khepraptah.khepra_site_backend.model;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 public record EventDTO(
@@ -9,6 +10,9 @@ public record EventDTO(
         String clientName,
         Date startDate,
         Date endDate,
+        int durationMinutes,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
         String streetAddress,
         String city,
         String state,

--- a/src/main/java/com/khepraptah/khepra_site_backend/model/EventType.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/model/EventType.java
@@ -1,0 +1,19 @@
+package com.khepraptah.khepra_site_backend.model;
+
+public enum EventType {
+    WORKSHOP(90),
+    BEMBE(120),
+    LECTURE(90),
+    EGUNGUN(60),
+    TRAINING(120);
+
+    private final int durationMinutes;
+
+    EventType(int durationMinutes) {
+        this.durationMinutes = durationMinutes;
+    }
+
+    public int getDurationMinutes() {
+        return durationMinutes;
+    }
+}

--- a/src/main/java/com/khepraptah/khepra_site_backend/model/Schedulable.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/model/Schedulable.java
@@ -1,0 +1,10 @@
+package com.khepraptah.khepra_site_backend.model;
+
+import java.time.LocalDateTime;
+
+public interface Schedulable {
+    LocalDateTime getStartTime();
+    LocalDateTime getEndTime();
+    boolean isVirtual();
+    String getCity();
+}

--- a/src/main/java/com/khepraptah/khepra_site_backend/repository/AppointmentRepository.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/repository/AppointmentRepository.java
@@ -1,11 +1,22 @@
 package com.khepraptah.khepra_site_backend.repository;
 
 import com.khepraptah.khepra_site_backend.model.Appointment;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public interface AppointmentRepository extends JpaRepository<Appointment, Long>{
     List<Appointment> findByUserId(String userId);
+
+    // Scheduling conflict check
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT a FROM Appointment a WHERE (:start < a.endTime AND :end > a.startTime)")
+    List<Appointment> findConflicts(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/khepraptah/khepra_site_backend/repository/EventRepository.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/repository/EventRepository.java
@@ -1,8 +1,19 @@
 package com.khepraptah.khepra_site_backend.repository;
 
 import com.khepraptah.khepra_site_backend.model.Event;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Repository
-public interface EventRepository extends JpaRepository<Event, Long>{}
+public interface EventRepository extends JpaRepository<Event, Long>{
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM Event e WHERE (:start < e.endTime AND :end > e.startTime)")
+    List<Event> findConflicts(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+}

--- a/src/main/java/com/khepraptah/khepra_site_backend/service/AppointmentService.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/service/AppointmentService.java
@@ -15,7 +15,5 @@ public interface AppointmentService {
     AppointmentDTO saveAppointment(AppointmentDTO appointmentDTO);
     AppointmentDTO updateAppointment(Long id, AppointmentDTO appointmentDTO);
     void deleteAppointment(Long id);
-
     List<AppointmentDTO> getAppointmentsByUserId(String userId);
-
 }

--- a/src/main/java/com/khepraptah/khepra_site_backend/service/EventServiceImpl.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/service/EventServiceImpl.java
@@ -2,19 +2,25 @@ package com.khepraptah.khepra_site_backend.service;
 
 import com.khepraptah.khepra_site_backend.model.Event;
 import com.khepraptah.khepra_site_backend.model.EventDTO;
+import com.khepraptah.khepra_site_backend.model.EventType;
 import com.khepraptah.khepra_site_backend.repository.EventRepository;
+import com.khepraptah.khepra_site_backend.service.ScheduleConflictService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 class EventServiceImpl implements EventService {
     private final EventRepository eventRepository;
+    private final ScheduleConflictService scheduleConflictService;
 
-    public EventServiceImpl(EventRepository eventRepository) {
+    public EventServiceImpl(EventRepository eventRepository, ScheduleConflictService scheduleConflictService) {
         this.eventRepository = eventRepository;
+        this.scheduleConflictService = scheduleConflictService;
     }
 
     @Override
@@ -29,27 +35,41 @@ class EventServiceImpl implements EventService {
         return eventRepository.findById(id).map(this::convertToDTO);
     }
 
-    @Override
+    @Transactional
     public EventDTO saveEvent(EventDTO eventDTO) {
         Event event = convertToEntity(eventDTO);
+        event.calculateEndTime();
+        scheduleConflictService.checkForConflicts(event);
         Event savedEvent = eventRepository.save(event);
         return convertToDTO(savedEvent);
     }
 
-    @Override
+    @Transactional
     public EventDTO updateEvent(Long id, EventDTO eventDTO) {
         Event event = eventRepository.findById(id).orElseThrow();
         event.setEventName(eventDTO.eventName());
         event.setEventType(eventDTO.eventType());
         event.setClientName(eventDTO.clientName());
         event.setStartDate(eventDTO.startDate());
-        event.setEndDate(eventDTO.endDate());
+        event.setStartTime(eventDTO.startTime());
+
+        try {
+            EventType appointmentType =EventType.valueOf(eventDTO.eventType().toUpperCase());
+            event.setDuration(appointmentType.getDurationMinutes());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid appointment type: " + eventDTO.eventType());
+        }
+
+        event.setEndTime(eventDTO.endTime());
         event.setStreetAddress(eventDTO.streetAddress());
         event.setCity(eventDTO.city());
         event.setState(eventDTO.state());
         event.setZipCode(eventDTO.zipCode());
         event.setDescription(eventDTO.description());
         event.setIsVirtual(eventDTO.isVirtual());
+
+        scheduleConflictService.checkForConflicts(event);
+
         Event updateEvent = eventRepository.save(event);
         return convertToDTO(updateEvent);
     }
@@ -60,16 +80,35 @@ class EventServiceImpl implements EventService {
     }
 
     private EventDTO convertToDTO(Event event) {
-        return new EventDTO(event.getId(), event.getEventName(), event.getEventType(), event.getClientName(), event.getStartDate(), event.getEndDate(), event.getStreetAddress(), event.getCity(), event.getState(), event.getZipCode(), event.getDescription(), event.getIsVirtual());
+        return new EventDTO(
+                event.getId(),
+                event.getEventName(),
+                event.getEventType(),
+                event.getClientName(),
+                event.getStartDate(),
+                event.getEndDate(),
+                event.getDuration(),
+                event.getStartTime(),
+                event.getEndTime(),
+                event.getStreetAddress(),
+                event.getCity(),
+                event.getState(),
+                event.getZipCode(),
+                event.getDescription(),
+                event.getIsVirtualRaw()
+        );
     }
 
     private Event convertToEntity(EventDTO eventDTO) {
         Event event = new Event();
+        event.setId(eventDTO.id());
         event.setEventName(eventDTO.eventName());
         event.setEventType(eventDTO.eventType());
         event.setClientName(eventDTO.clientName());
         event.setStartDate(eventDTO.startDate());
-        event.setEndDate(eventDTO.endDate());
+        event.setDuration(eventDTO.durationMinutes());
+        event.setStartTime(eventDTO.startTime());
+        event.setEndTime(eventDTO.endTime());
         event.setStreetAddress(eventDTO.streetAddress());
         event.setCity(eventDTO.city());
         event.setState(eventDTO.state());

--- a/src/main/java/com/khepraptah/khepra_site_backend/service/ScheduleConflictService.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/service/ScheduleConflictService.java
@@ -1,0 +1,56 @@
+package com.khepraptah.khepra_site_backend.service;
+
+import com.khepraptah.khepra_site_backend.exception.ConflictException;
+import com.khepraptah.khepra_site_backend.model.Appointment;
+import com.khepraptah.khepra_site_backend.model.Event;
+import com.khepraptah.khepra_site_backend.model.Schedulable;
+import com.khepraptah.khepra_site_backend.repository.AppointmentRepository;
+import com.khepraptah.khepra_site_backend.repository.EventRepository;
+import com.khepraptah.khepra_site_backend.util.BufferUtils;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ScheduleConflictService {
+    private final AppointmentRepository appointmentRepo;
+    private final EventRepository eventRepo;
+
+    public ScheduleConflictService(AppointmentRepository appointmentRepo, EventRepository eventRepo) {
+        this.appointmentRepo = appointmentRepo;
+        this.eventRepo = eventRepo;
+    }
+
+    /**
+     * Checks if a schedulable item conflicts with existing appointments or events,
+     * considering buffer times.
+     */
+    @Transactional
+    public void checkForConflicts(Schedulable newItem) {
+        if (newItem.getStartTime() == null || newItem.getEndTime() == null) {
+            throw new IllegalArgumentException("Start time or end time cannot be null when checking for conflicts.");
+        }
+
+        Duration buffer = BufferUtils.getBufferDuration(newItem);
+        LocalDateTime bufferedStart = newItem.getStartTime().minus(buffer);
+        LocalDateTime bufferedEnd = newItem.getEndTime().plus(buffer);
+
+        List<Appointment> appointmentConflicts = appointmentRepo.findConflicts(bufferedStart, bufferedEnd)
+                .stream()
+                .filter(existing -> !existing.equals(newItem)) // avoid self-conflict
+                .collect(Collectors.toList());
+
+        List<Event> eventConflicts = eventRepo.findConflicts(bufferedStart, bufferedEnd)
+                .stream()
+                .filter(existing -> !existing.equals(newItem)) // avoid self-conflict
+                .collect(Collectors.toList());
+
+        if (!appointmentConflicts.isEmpty() || !eventConflicts.isEmpty()) {
+            throw new ConflictException("‼️ Scheduling conflict detected, item not booked.");
+        }
+    }
+}

--- a/src/main/java/com/khepraptah/khepra_site_backend/util/BufferUtils.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/util/BufferUtils.java
@@ -1,0 +1,29 @@
+package com.khepraptah.khepra_site_backend.util;
+
+import com.khepraptah.khepra_site_backend.model.Schedulable;
+
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Optional;
+
+public class BufferUtils {
+    public static Duration getBufferDuration(Schedulable item) {
+        if (item.isVirtual()) {
+            return Duration.ofMinutes(15);
+        }
+
+        String location = Optional.ofNullable(item.getCity())
+                .orElse("virtual")
+                .toLowerCase(Locale.US);
+        if (location.contains("bremerton")) {
+            return Duration.ofMinutes(150); // 2.5 hours
+        } else if (location.contains("seattle")) {
+            return Duration.ofMinutes(45);
+        } else if (location.contains("virtual")) {
+            return Duration.ofMinutes(15);
+        }
+
+        // Default buffer
+        return Duration.ofMinutes(15);
+    }
+}


### PR DESCRIPTION
This patch ensures that the backend receives and stores the endTime field when appointments and events are created or updated. It is a necessary step toward enabling buffer-aware conflict checking.

Changes Include:
    - Modified the AppointmentController and AppointmentServiceImpl to accept and log the endTime from incoming requests.
    - Modified the EventController and EventServiceImpl to accept and log the endTime from incoming requests.
    - Ensured the AppointmentDTO and EventDTO correctly maps endTimes to the entity.
   
