### PR TITLE
feat: search database for appointments by email

### DIFF
--- a/src/main/java/com/khepraptah/khepra_site_backend/controller/AppointmentController.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/controller/AppointmentController.java
@@ -28,12 +28,18 @@ public class AppointmentController {
     @GetMapping
     public ResponseEntity<List<AppointmentDTO>> getAppointments(
             @RequestParam(required = false) String userId,
+            @RequestParam(required = false) String email,
             @RequestParam(required = false) String filter,
-            @RequestParam(required = false) Integer daysRange // optional, for extended control
+            @RequestParam(required = false) Integer daysRange, // optional, for extended control
+            @RequestParam(defaultValue = "false") Boolean includeAdminAppointments
     ) {
-        List<AppointmentDTO> appointments = (userId != null && !userId.isEmpty())
-                ? appointmentService.getAppointmentsByUserId(userId)
-                : appointmentService.getAllAppointments();
+        List<AppointmentDTO> appointments;
+
+        if (userId == null && email == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        }
+
+        appointments = appointmentService.getAllAppointments(userId, email, includeAdminAppointments);
 
         LocalDateTime now = LocalDateTime.now();
 

--- a/src/main/java/com/khepraptah/khepra_site_backend/repository/AppointmentRepository.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/repository/AppointmentRepository.java
@@ -15,6 +15,14 @@ import java.util.List;
 public interface AppointmentRepository extends JpaRepository<Appointment, Long>{
     List<Appointment> findByUserId(String userId);
 
+    List<Appointment> findByEmail(String email);
+
+    @Query("SELECT a FROM Appointment a WHERE a.userId = :userId AND a.createdByAdmin = true")
+    List<Appointment> findAdminCreatedAppointmentsByUserId(@Param("userId") String userId);
+
+    @Query("SELECT a FROM Appointment a WHERE a.email = :email AND a.createdByAdmin = true")
+    List<Appointment> findAdminCreatedAppointmentsByEmail(@Param("email") String email);
+
     // Scheduling conflict check
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT a FROM Appointment a WHERE a.startTime < :end AND a.endTime > :start")

--- a/src/main/java/com/khepraptah/khepra_site_backend/service/AppointmentService.java
+++ b/src/main/java/com/khepraptah/khepra_site_backend/service/AppointmentService.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 @Service
 public interface AppointmentService {
-    List<AppointmentDTO> getAllAppointments();
+    List<AppointmentDTO> getAllAppointments(String userId, String email, boolean includeAdminAppointments);
     Optional<AppointmentDTO> getAppointmentById(Long id);
     AppointmentDTO saveAppointment(AppointmentDTO appointmentDTO);
     AppointmentDTO updateAppointment(Long id, AppointmentDTO appointmentDTO);


### PR DESCRIPTION
### Changes:
2. **Appointment History Logic**:
   - Adjusted logic for fetching and displaying a user's appointment history to include **admin-created appointments**.
   - Modified the database queries and appointment creation logic to ensure admin-created appointments are saved and associated with the user’s historical data.

### Reason:
- This change ensures that **admin-created appointments** are properly included in a user's appointment history, ensuring complete tracking and visibility.
- Previously, only user-created appointments were included in the user's history. This update ensures all appointments, regardless of creator, are included.

### Impact:
- **Admin-created appointments** are now reflected in the user's appointment history.
- The backend now supports fetching and saving appointments from both users and admins within the user's appointment history.
